### PR TITLE
feat: support iso 8601 with no timezone info as local date on Safari, IE9

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "webpack": "^4.41.5",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.10"
+  },
+  "dependencies": {
+    "tui-code-snippet": "^2.3.1"
   }
 }

--- a/src/localDate.js
+++ b/src/localDate.js
@@ -3,41 +3,51 @@ import isString from 'tui-code-snippet/type/isString';
  * datetime regex from https://www.regexpal.com/94925
  * timezone regex from moment
  */
-const isoregex = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?([+-]\d\d(?::?\d\d)?|\s*Z)?$/;
+const rISO8601 = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?([+-]\d\d(?::?\d\d)?|\s*Z)?$/;
 
 function throwNotSupported() {
   throw new Error('This operation is not supported.');
 }
 
-// eslint-disable-next-line complexity
-function getDateTime(match) {
-  const [y, m, d, h, M, s, ms, zoneInfo] = match.slice(1);
+function getDateTime(dateString) {
+  const match = rISO8601.exec(dateString);
+  if (match) {
+    const [, y, M, d, h, m, s, ms, zoneInfo] = match;
 
-  return {
-    y: Number(y),
-    m: Number(m) - 1 || 0,
-    d: Number(d) || 0,
-    h: Number(h) || 0,
-    M: Number(M) || 0,
-    s: Number(s) || 0,
-    ms: Number(ms) || 0,
-    zoneInfo
-  };
+    return {
+      y: Number(y),
+      M: Number(M) - 1,
+      d: Number(d),
+      h: Number(h),
+      m: Number(m),
+      s: Number(s),
+      ms: Number(ms) || 0,
+      zoneInfo
+    };
+  }
+
+  return null;
+}
+
+function createFromDateString(dateString) {
+  const info = getDateTime(dateString);
+  if (info && !info.zoneInfo) {
+    const { y, M, d, h, m, s, ms } = info;
+
+    return new Date(y, M, d, h, m, s, ms);
+  }
+
+  return null;
 }
 
 export default class LocalDate {
   constructor(...args) {
-    if (args[0] instanceof Date) {
-      this.d = new Date(args[0].getTime());
-    } else if (isString(args[0])) {
-      const match = isoregex.exec(args[0]);
-      if (match) {
-        const info = getDateTime(match);
-        const { y, m, d, h, M, s, ms, zoneInfo } = info;
-        if (!zoneInfo) {
-          this.d = new Date(y, m, d, h, M, s, ms);
-        }
-      }
+    const [firstArg] = args;
+
+    if (firstArg instanceof Date) {
+      this.d = new Date(firstArg.getTime());
+    } else if (isString(firstArg) && args.length === 1) {
+      this.d = createFromDateString(firstArg);
     }
 
     if (!this.d) {

--- a/src/localDate.js
+++ b/src/localDate.js
@@ -1,11 +1,46 @@
+import isString from 'tui-code-snippet/type/isString';
+/**
+ * datetime regex from https://www.regexpal.com/94925
+ * timezone regex from moment
+ */
+const isoregex = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?([+-]\d\d(?::?\d\d)?|\s*Z)?$/;
+
 function throwNotSupported() {
   throw new Error('This operation is not supported.');
 }
+
+// eslint-disable-next-line complexity
+function getDateTime(match) {
+  const [y, m, d, h, M, s, ms, zoneInfo] = match.slice(1);
+
+  return {
+    y: Number(y),
+    m: Number(m) - 1 || 0,
+    d: Number(d) || 0,
+    h: Number(h) || 0,
+    M: Number(M) || 0,
+    s: Number(s) || 0,
+    ms: Number(ms) || 0,
+    zoneInfo
+  };
+}
+
 export default class LocalDate {
   constructor(...args) {
     if (args[0] instanceof Date) {
       this.d = new Date(args[0].getTime());
-    } else {
+    } else if (isString(args[0])) {
+      const match = isoregex.exec(args[0]);
+      if (match) {
+        const info = getDateTime(match);
+        const { y, m, d, h, M, s, ms, zoneInfo } = info;
+        if (!zoneInfo) {
+          this.d = new Date(y, m, d, h, M, s, ms);
+        }
+      }
+    }
+
+    if (!this.d) {
       this.d = new Date(...args);
     }
   }

--- a/src/momentDate.js
+++ b/src/momentDate.js
@@ -116,19 +116,19 @@ export default class MomentDate {
     return this.getTime();
   }
 
-  setHours(h, M = this.getMinutes(), s = this.getSeconds(), ms = this.getMilliseconds()) {
+  setHours(h, m = this.getMinutes(), s = this.getSeconds(), ms = this.getMilliseconds()) {
     this.m
       .hours(h)
-      .minutes(M)
+      .minutes(m)
       .seconds(s)
       .milliseconds(ms);
 
     return this.getTime();
   }
 
-  setMinutes(M, s = this.getSeconds(), ms = this.getMilliseconds()) {
+  setMinutes(m, s = this.getSeconds(), ms = this.getMilliseconds()) {
     this.m
-      .minutes(M)
+      .minutes(m)
       .seconds(s)
       .milliseconds(ms);
 

--- a/test/localDate.spec.js
+++ b/test/localDate.spec.js
@@ -45,3 +45,17 @@ test('LocalDate uses local date setters', () => {
   expect(date.setSeconds(1, 0)).toBe(time + ONE_MINUTE + ONE_SECOND);
   expect(date.setMilliseconds(1)).toBe(time + ONE_MINUTE + ONE_SECOND + 1);
 });
+
+test('If iso 8601 date string and no timezone info, LocalDate uses new Date(year, monthIndex[, day[, hour[, minutes[, seconds[, milliseconds]]]]]);', () => {
+  const nativeDate = new Date(2020, 0, 29, 19, 20, 0);
+  const date = new LocalDate('2020-01-29T19:20:00');
+
+  expect(date.getTime()).toBe(nativeDate.getTime());
+});
+
+test('If iso 8601 date string and timezone info, LocalDate uses new Date(dateString);', () => {
+  const nativeDate = new Date('2020-01-29T19:20:00Z');
+  const date = new LocalDate('2020-01-29T19:20:00Z');
+
+  expect(date.getTime()).toBe(nativeDate.getTime());
+});


### PR DESCRIPTION
## If dateString is iso 8601 with no timezone info, Safari and IE9 treat it as UTC. Others treat it as local time.

```js
new Date('2015-11-30T23:59:59');
new Date('2015-11-30T23:59:59+09:00');
```

### (A) Chrome, IE10, IE11, Edge, Firefox treat it as local time
![image](https://user-images.githubusercontent.com/26706716/74519713-98a73500-4f59-11ea-94f1-1796f12086b9.png)


### (B) Safari, IE9 treat it as UTC time
![image](https://user-images.githubusercontent.com/26706716/74519732-9fce4300-4f59-11ea-859d-6ce0a41a69d4.png)

## Solution
This constructor `new Date(year, monthIndex[, day[, hour[, minutes[, seconds[, milliseconds]]]]]);` treats dateString as local time. So all target browsers treat it as local time.

Tested on
* IE9, 10, 11
* Edge
* Chrome
* Firefox
* Safari