### PR TITLE
fix: regular expression for ISO8601 milliseconds error

### DIFF
--- a/src/localDate.js
+++ b/src/localDate.js
@@ -3,7 +3,7 @@ import isString from 'tui-code-snippet/type/isString';
  * datetime regex from https://www.regexpal.com/94925
  * timezone regex from moment
  */
-const rISO8601 = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?([+-]\d\d(?::?\d\d)?|\s*Z)?$/;
+const rISO8601 = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.)?([0-9]+)?([+-]\d\d(?::?\d\d)?|\s*Z)?$/;
 
 function throwNotSupported() {
   throw new Error('This operation is not supported.');
@@ -12,7 +12,7 @@ function throwNotSupported() {
 function getDateTime(dateString) {
   const match = rISO8601.exec(dateString);
   if (match) {
-    const [, y, M, d, h, m, s, ms, zoneInfo] = match;
+    const [, y, M, d, h, m, s, __, ms, zoneInfo] = match;
 
     return {
       y: Number(y),

--- a/test/localDate.spec.js
+++ b/test/localDate.spec.js
@@ -60,9 +60,20 @@ test('If iso 8601 date string and timezone info, LocalDate uses new Date(dateStr
   expect(date.getTime()).toBe(nativeDate.getTime());
 });
 
-test('If milliseconds with dateString, LocalDate can get a valid date', () => {
-  const nativeDate = new Date('2020-01-29T19:20:00.999');
-  const date = new LocalDate('2020-01-29T19:20:00.999');
-
-  expect(date.getTime()).toBe(nativeDate.getTime());
+test('If dateString matches the regular expression, LocalDate can get a valid date', () => {
+  expect(new Date('2020-01-29T19:20:00.999').getTime()).toBe(
+    new LocalDate('2020-01-29T19:20:00.999').getTime()
+  );
+  expect(new Date('2020-01-29T19:20:00').getTime()).toBe(
+    new LocalDate('2020-01-29T19:20:00').getTime()
+  );
+  expect(new Date('2020-01-29T19:20:00.999+09:00').getTime()).toBe(
+    new LocalDate('2020-01-29T19:20:00.999+09:00').getTime()
+  );
+  expect(new Date('2020-01-29T19:20:00.999Z').getTime()).toBe(
+    new LocalDate('2020-01-29T19:20:00.999Z').getTime()
+  );
+  expect(new Date('2020-01-29T19:20:00+09:00').getTime()).toBe(
+    new LocalDate('2020-01-29T19:20:00+09:00').getTime()
+  );
 });

--- a/test/localDate.spec.js
+++ b/test/localDate.spec.js
@@ -59,3 +59,10 @@ test('If iso 8601 date string and timezone info, LocalDate uses new Date(dateStr
 
   expect(date.getTime()).toBe(nativeDate.getTime());
 });
+
+test('If milliseconds with dateString, LocalDate can get a valid date', () => {
+  const nativeDate = new Date('2020-01-29T19:20:00.999');
+  const date = new LocalDate('2020-01-29T19:20:00.999');
+
+  expect(date.getTime()).toBe(nativeDate.getTime());
+});


### PR DESCRIPTION
IE9 doesn't accept 'yyyy-mm-ddThh:MM:ss.ms', especially `ms`. In this case, the regular expression takes care of it, but wouldn't. Because of regular expression has an error with `\\.`.
### tested for data
```
2015-07-31T23:59:59.999
2015-07-31T23:59:59
2015-07-31T23:59:59.999+09:00
2015-07-31T23:59:59.999Z
2015-07-31T23:59:59+09:00
```